### PR TITLE
Add tests for zircon saturation and slight increase in performance

### DIFF
--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -21,16 +21,14 @@ export adjust_chemical_system, TE_prediction, get_OL_KDs_database, adjust_bulk_4
 function anhydrous_renormalization( bulk    :: Vector{Float64},
                                     oxide   :: Vector{String})
 
-    bulk_dry    = zeros(Float64, length(bulk))
-    H2O = findall(oxide .== "H2O")
-    if ~isempty(H2O)
-        non_H2O     = findall(oxide .!= "H2O")
-        H2O         = H2O[1]
-
-        bulk_dry[non_H2O] .= bulk[non_H2O]
+    if "H2O" in oxide
+        H2O_index = findfirst(==("H2O"), oxide)
+        bulk_dry = copy(bulk)
+        bulk_dry[H2O_index] = 0.0
         bulk_dry ./= sum(bulk_dry)
     else
-        print(" No water oxide in the system! \n")
+        println("No water oxide in the system!")
+        bulk_dry = bulk ./ sum(bulk)
     end
 
     return bulk_dry

--- a/julia/Zircon_saturation.jl
+++ b/julia/Zircon_saturation.jl
@@ -1,31 +1,35 @@
 # Routine to compute zircon saturation and adjust bulk-rock composition when zircon crystallizes
-# NR 12/04/2023
+# NR 12/04/2024, benchmarked HD 25/06/2024
 
-function zirconium_saturation(  out     :: MAGEMin_C.gmin_struct{Float64, Int64}; 
+function zirconium_saturation(  out     :: MAGEMin_C.gmin_struct{Float64, Int64};
                                 model   :: String = "WH"    )
 
-    if out.frac_M > 0.0                            
+    if out.frac_M > 0.0
         if model == "WH" || model == "B"
-            ref_ox      = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "K2O"; "Na2O"; "TiO2"; "O"; "Cr2O3"; "MnO"; "H2O"; "S"];
-            # ratio_cation= [1/3.0,2/5,1/2,1/2,1/2,2/5,2/3,2/3,1/3,1,2/5,1/2,2/3,1]
-            n_cation    = [1.0,2,1,1,1,2,2,1,1,2,1,2,1]
-          
-            cation_name = ["Si"; "Al"; "Ca"; "Mg"; "Fe"; "K"; "Na"; "Ti"; "O"; "Cr"; "Mn"; "H"; "S"]
-            
-            cation_idx  = [findfirst(isequal(x), ref_ox) for x in out.oxides];
+            ref_ox      = ("SiO2", "Al2O3", "CaO", "MgO", "FeO", "K2O", "Na2O", "TiO2", "O", "Cr2O3", "MnO", "H2O", "S")
+            n_cation    = (1.0, 2, 1, 1, 1, 2, 2, 1, 1, 2, 1, 2, 1)
+            cation_name = ["Si", "Al", "Ca", "Mg", "Fe", "K", "Na", "Ti", "O", "Cr", "Mn", "H", "S"]
+
+            # Calculate cation_idx using a comprehension with the tuple ref_ox
+            cation_idx  = [findfirst(isequal(x), ref_ox) for x in out.oxides]
 
             bulk_M_dry  = anhydrous_renormalization(out.bulk_M,out.oxides)
 
-            cation      = bulk_M_dry .*n_cation[cation_idx];
-            cation      = cation ./ sum(cation);
+            cation      = zeros(length(cation_idx))
+            # # Perform in-place multiplication to fill the cation array
+            @inbounds for i in axes(cation, 1)
+                cation[i] = bulk_M_dry[i] * n_cation[cation_idx[i]]
+            end
 
-            Na          = findall(cation_name[cation_idx] .== "Na")[1];
-            K           = findall(cation_name[cation_idx] .== "K")[1];
-            Ca          = findall(cation_name[cation_idx] .== "Ca")[1];
-            Al          = findall(cation_name[cation_idx] .== "Al")[1];
-            Si          = findall(cation_name[cation_idx] .== "Si")[1];
+            sum_cation  = sum(cation);
 
-            M           = (cation[Na] + cation[K]+ 2.0*cation[Ca])/(cation[Al]*cation[Si]);
+            Na          = findfirst(==("Na"), cation_name[cation_idx]);
+            K           = findfirst(==("K"), cation_name[cation_idx]);
+            Ca          = findfirst(==("Ca"), cation_name[cation_idx]);
+            Al          = findfirst(==("Al"), cation_name[cation_idx]);
+            Si          = findfirst(==("Si"), cation_name[cation_idx]);
+
+            M           = (cation[Na] + cation[K]+ 2.0*cation[Ca]) / (cation[Al] * cation[Si]) * sum_cation;
             C_zr_zrn    = 497644;
 
             # Watson & Harrison (1983)
@@ -38,20 +42,38 @@ function zirconium_saturation(  out     :: MAGEMin_C.gmin_struct{Float64, Int64}
             end
         # Crisp and Berry 2022
         elseif model == "CB"
-            opt_basi_oxides = ["SiO2","TiO2","Al2O3","MgO","MnO","FeO","Fe2O3","CaO","Na2O","K2O","P2O5","H2O"]
-            optical_basicity= [0.48,0.75,0.60,0.78,0.96,1.00,0.77,1.00,1.15,1.40,0.33,0.40]
-            n_oxygen        = [2.0,2,3,1,1,1,3,1,1,1,5,1]
-            
-            commonOxide   =  intersect(out.oxides,opt_basi_oxides)
+            opt_basi_oxides = ("SiO2","TiO2","Al2O3","MgO","MnO","FeO","Fe2O3","CaO","Na2O","K2O","P2O5","H2O")
+            optical_basicity= (0.48,0.75,0.60,0.78,0.96,1.00,0.77,1.00,1.15,1.40,0.33,0.40)
+            n_oxygen        = (2.0,2,3,1,1,1,3,1,1,1,5,1)
+
+            commonOxide   =  intersect(Set(out.oxides),Set(opt_basi_oxides))
             idOx_MM       = [findfirst(isequal(x), out.oxides) for x in commonOxide]
             idOx_OB       = [findfirst(isequal(x), opt_basi_oxides) for x in commonOxide]
 
             liqCompNorm   = out.bulk_M[idOx_MM] ./ sum(out.bulk_M[idOx_MM])
             oxListDry     = findall(commonOxide .!= "H2O")
-            opt_basicity  = sum(liqCompNorm[oxListDry] .* optical_basicity[idOx_OB[oxListDry]].* n_oxygen[idOx_OB[oxListDry]]) / sum(liqCompNorm[oxListDry] .* n_oxygen[idOx_OB[oxListDry]])
-            xH2O          = liqCompNorm[findall(commonOxide .== "H2O")[1]]
 
-            C_zr_liq   = 10^(0.96 - 5790.0/(out.T_C+273.15) - 1.28*(out.P_kbar/10.0) + 12.39*opt_basicity + 0.83*xH2O + 2.06*(out.P_kbar/10.0)*opt_basicity)
+            # Compute optical basicity directly without intermediate arrays
+            opt_basicity_numerator = 0.0
+            opt_basicity_denominator = 0.0
+
+            @inbounds for i in oxListDry
+                idx = idOx_OB[i]
+                ob = optical_basicity[idx]
+                no = n_oxygen[idx]
+                comp = liqCompNorm[i]
+                opt_basicity_numerator += comp * ob * no
+                opt_basicity_denominator += comp * no
+            end
+            opt_basicity = opt_basicity_numerator / opt_basicity_denominator
+
+            # # Directly access the water content without creating a temporary array
+            xH2O_index = findfirst(==("H2O"), String.(commonOxide))
+            xH2O = liqCompNorm[xH2O_index]
+
+            # # Compute C_zr_liq
+            C_zr_liq = 10^(0.96 - 5790.0 / (out.T_C + 273.15) - 1.28 * (out.P_kbar * 0.1) + 12.39 * opt_basicity + 0.83 * xH2O + 2.06 * (out.P_kbar * 0.1) * opt_basicity)
+            # C_zr_liq = 0
         else
             print("Model $model for zirconium saturation is invalid\n")
         end
@@ -59,16 +81,16 @@ function zirconium_saturation(  out     :: MAGEMin_C.gmin_struct{Float64, Int64}
         print("Cannot compute zirconium saturation in liquid if melt is not predicted!\n")
         C_zr_liq = -1
     end
-     
-    return C_zr_liq 
+
+    return C_zr_liq
 end
 
 function adjust_bulk_4_zircon(  zr_liq  ::  Float64,
                                 sat_liq ::  Float64 )
 
-    SiO2_wt         = 0.0   
-    O2_wt           = 0.0        
-    zircon_wt       = 0.0             
+    SiO2_wt         = 0.0
+    O2_wt           = 0.0
+    zircon_wt       = 0.0
     zircon_excess   = (zr_liq - sat_liq)/1e4
 
     zircon_wt   = zircon_excess*0.497644
@@ -76,5 +98,5 @@ function adjust_bulk_4_zircon(  zr_liq  ::  Float64,
     O2_wt       = (zircon_wt *0.174570)
 
 
-    return zircon_wt ,SiO2_wt ,O2_wt 
+    return zircon_wt ,SiO2_wt ,O2_wt
 end

--- a/julia/Zircon_saturation.jl
+++ b/julia/Zircon_saturation.jl
@@ -73,7 +73,6 @@ function zirconium_saturation(  out     :: MAGEMin_C.gmin_struct{Float64, Int64}
 
             # # Compute C_zr_liq
             C_zr_liq = 10^(0.96 - 5790.0 / (out.T_C + 273.15) - 1.28 * (out.P_kbar * 0.1) + 12.39 * opt_basicity + 0.83 * xH2O + 2.06 * (out.P_kbar * 0.1) * opt_basicity)
-            # C_zr_liq = 0
         else
             print("Model $model for zirconium saturation is invalid\n")
         end


### PR DESCRIPTION
Ok, so I've benchmarked again everything and all is green for the zircon saturation. 
I've also slighty increase the performance without pushing too much (there is a lot of array allocations, but there is no easy way to get ride of it with how the code is structured, and as the input oxides depends on the database)

Before this PR:

```
# for Boehnke et al., 2013
# 2.136 μs (35 allocations: 3.19 KiB) 
# Crisp and Berry 2022
# 3.480 μs (62 allocations: 6.16 KiB) CB
```

After this PR:

```
# for Boehnke et al., 2013
# 1.409 μs (18 allocations: 2.12 KiB)
# Crisp and Berry 2022
# 2.592 μs (29 allocations: 3.94 KiB)
```

